### PR TITLE
Update to work on all lats pages

### DIFF
--- a/lats-helper.user.js
+++ b/lats-helper.user.js
@@ -2,10 +2,10 @@
 // @name           LATS Helper
 // @namespace      https://chrome.google.com/webstore/detail/lats-helper/jmkgmheopekejeiondjdokbdckkeikeh?hl=en
 // @include        https://oftlats.cma.com/*
-// @include        https://*.lats.ny.gov/*
+// @include        https://*lats*.gov/*
 // @include        https://*.cma.com/*
-// @version        1.2.5
-// @updated        2017-05-21
+// @version        1.2.6
+// @updated        2018-12-11
 // ==/UserScript==
 
 (function () {

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
         {
             "matches": [
                 "https://*.cma.com/*",
-                "https://*.lats.ny.gov/*"
+                "https://*lats*.gov/*"
             ],
             "js": ["lats-helper.user.js"],
             "run_at": "document_end"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "LATS Helper",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "description": "Makes filling in your LATS timesheet and TDS easier",
     "content_scripts": [
         {


### PR DESCRIPTION
nysed.gov uses a different URL schema for lats. updating to work on all "*lats*.gov" URLS

Can you also re-pack this and update the chrome addon?

Thanks!